### PR TITLE
Add initial support for multiple GeoPackage specification versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: precise
+dist: trusty
 language: c
 
 rvm:
@@ -9,7 +9,6 @@ compiler:
 
 before_install:
  - echo "yes" | sudo add-apt-repository ppa:ubuntugis/ppa
- - echo "yes" | sudo add-apt-repository ppa:george-edison55/precise-backports
  - sudo apt-get update -qq
  - sudo apt-get install libgeos-3.3.8 libgeos-c1 libgeos-dev
  - sudo apt-get install cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ compiler:
 
 before_install:
  - echo "yes" | sudo add-apt-repository ppa:ubuntugis/ppa
+ - echo "yes" | sudo add-apt-repository ppa:george-edison55/precise-backports
  - sudo apt-get update -qq
  - sudo apt-get install libgeos-3.3.8 libgeos-c1 libgeos-dev
  - sudo apt-get install cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ compiler:
 before_install:
  - echo "yes" | sudo add-apt-repository ppa:ubuntugis/ppa
  - sudo apt-get update -qq
- - sudo apt-get install libgeos-3.3.8 libgeos-c1 libgeos-dev
+ - sudo apt-get install libgeos-3.5.0 libgeos-c1v5 libgeos-dev
  - sudo apt-get install cmake
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: c
 
 rvm:
@@ -8,7 +9,6 @@ compiler:
 
 before_install:
  - echo "yes" | sudo add-apt-repository ppa:ubuntugis/ppa
- - echo "yes" | sudo add-apt-repository ppa:kalakris/cmake
  - sudo apt-get update -qq
  - sudo apt-get install libgeos-3.3.8 libgeos-c1 libgeos-dev
  - sudo apt-get install cmake

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ that SQLite provides.
 libgpkg exposes a number of SQLite extension entry points:
 
 - sqlite3_gpkg_init: geopackage mode
+- sqlite3_gpkg_1_0_init: geopackage 1.0 mode
+- sqlite3_gpkg_1_1_init: geopacakge 1.1 mode
+- sqlite3_gpkg_1_2_init: geopackage 1.2 mode
+- sqlite3_gpkg_spl2_init: spatialite 2.x mode
 - sqlite3_gpkg_spl2_init: spatialite 2.x mode
 - sqlite3_gpkg_spl3_init: spatialite 3.x mode
 - sqlite3_gpkg_spl4_init: spatialite 4.x mode

--- a/gpkg/gpkg.c
+++ b/gpkg/gpkg.c
@@ -29,18 +29,18 @@ GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_auto_init(sqlite3 *db, const char **pzErr
 }
 
 GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk) {
-  return sqlite3_gpkg1_2_init(db, pzErrMsg, pThunk);
+  return sqlite3_gpkg_1_2_init(db, pzErrMsg, pThunk);
 }
 
-GPKG_EXPORT int GPKG_CALL sqlite3_gpkg1_0_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk) {
+GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_1_0_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk) {
   return spatialdb_init(db, pzErrMsg, pThunk, spatialdb_geopackage10_schema());
 }
 
-GPKG_EXPORT int GPKG_CALL sqlite3_gpkg1_1_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk) {
+GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_1_1_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk) {
   return spatialdb_init(db, pzErrMsg, pThunk, spatialdb_geopackage11_schema());
 }
 
-GPKG_EXPORT int GPKG_CALL sqlite3_gpkg1_2_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk) {
+GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_1_2_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk) {
   return spatialdb_init(db, pzErrMsg, pThunk, spatialdb_geopackage12_schema());
 }
 

--- a/gpkg/gpkg.c
+++ b/gpkg/gpkg.c
@@ -29,7 +29,19 @@ GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_auto_init(sqlite3 *db, const char **pzErr
 }
 
 GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk) {
-  return spatialdb_init(db, pzErrMsg, pThunk, spatialdb_geopackage_schema());
+  return sqlite3_gpkg1_2_init(db, pzErrMsg, pThunk);
+}
+
+GPKG_EXPORT int GPKG_CALL sqlite3_gpkg1_0_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk) {
+  return spatialdb_init(db, pzErrMsg, pThunk, spatialdb_geopackage10_schema());
+}
+
+GPKG_EXPORT int GPKG_CALL sqlite3_gpkg1_1_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk) {
+  return spatialdb_init(db, pzErrMsg, pThunk, spatialdb_geopackage11_schema());
+}
+
+GPKG_EXPORT int GPKG_CALL sqlite3_gpkg1_2_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk) {
+  return spatialdb_init(db, pzErrMsg, pThunk, spatialdb_geopackage12_schema());
 }
 
 GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_spl2_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk) {

--- a/gpkg/gpkg.h
+++ b/gpkg/gpkg.h
@@ -53,17 +53,17 @@ GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_init(sqlite3 *db, const char **pzErrMsg, 
 /**
  * Entry point for the libgpkg SQLite extension that forces usage of the GeoPackage 1.0 database schema.
  */
-GPKG_EXPORT int GPKG_CALL sqlite3_gpkg1_0_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk);
+GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_1_0_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk);
 
 /**
  * Entry point for the libgpkg SQLite extension that forces usage of the GeoPackage 1.1 database schema.
  */
-GPKG_EXPORT int GPKG_CALL sqlite3_gpkg1_1_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk);
+GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_1_1_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk);
 
 /**
  * Entry point for the libgpkg SQLite extension that forces usage of the GeoPackage 1.2 database schema.
  */
-GPKG_EXPORT int GPKG_CALL sqlite3_gpkg1_2_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk);
+GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_1_2_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk);
 
 /**
  * Entry point for the libgpkg SQLite extension that attempts to autodetect the schema to use.

--- a/gpkg/gpkg.h
+++ b/gpkg/gpkg.h
@@ -51,6 +51,21 @@ GPKG_EXPORT const char *GPKG_CALL gpkg_libversion();
 GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk);
 
 /**
+ * Entry point for the libgpkg SQLite extension that forces usage of the GeoPackage 1.0 database schema.
+ */
+GPKG_EXPORT int GPKG_CALL sqlite3_gpkg1_0_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk);
+
+/**
+ * Entry point for the libgpkg SQLite extension that forces usage of the GeoPackage 1.1 database schema.
+ */
+GPKG_EXPORT int GPKG_CALL sqlite3_gpkg1_1_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk);
+
+/**
+ * Entry point for the libgpkg SQLite extension that forces usage of the GeoPackage 1.2 database schema.
+ */
+GPKG_EXPORT int GPKG_CALL sqlite3_gpkg1_2_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk);
+
+/**
  * Entry point for the libgpkg SQLite extension that attempts to autodetect the schema to use.
  */
 GPKG_EXPORT int GPKG_CALL sqlite3_gpkg_auto_init(sqlite3 *db, const char **pzErrMsg, const sqlite3_api_routines *pThunk);

--- a/gpkg/gpkg_db.c
+++ b/gpkg/gpkg_db.c
@@ -149,7 +149,7 @@ static table_info_t gpkg_data_columns = {
   NULL, 0
 };
 
-static column_info_t gpkg_data_column_constraints_columns[] = {
+static column_info_t gpkg_data_column_constraints_columns_10[] = {
   {"constraint_name", "TEXT", N, SQL_NOT_NULL | SQL_UNIQUE(1), NULL},
   {"constraint_type", "TEXT", N, SQL_NOT_NULL | SQL_UNIQUE(1), NULL},
   {"value", "TEXT", N, SQL_UNIQUE(1), NULL},
@@ -160,10 +160,27 @@ static column_info_t gpkg_data_column_constraints_columns[] = {
   {"description", "TEXT", N, 0, NULL},
   {NULL, NULL, N, 0, NULL}
 };
-static table_info_t gpkg_data_column_constraints = {
+static table_info_t gpkg_data_column_constraints_10 = {
   "gpkg_data_column_constraints",
-  gpkg_data_column_constraints_columns,
+  gpkg_data_column_constraints_columns_10,
   NULL, 0
+};
+
+static column_info_t gpkg_data_column_constraints_columns_11[] = {
+        {"constraint_name", "TEXT", N, SQL_NOT_NULL | SQL_UNIQUE(1), NULL},
+        {"constraint_type", "TEXT", N, SQL_NOT_NULL | SQL_UNIQUE(1), NULL},
+        {"value", "TEXT", N, SQL_UNIQUE(1), NULL},
+        {"min", "NUMERIC", N, 0, NULL},
+        {"min_is_inclusive", "BOOLEAN", N, 0, NULL},
+        {"max", "NUMERIC", N, 0, NULL},
+        {"max_is_inclusive", "BOOLEAN", N, 0, NULL},
+        {"description", "TEXT", N, 0, NULL},
+        {NULL, NULL, N, 0, NULL}
+};
+static table_info_t gpkg_data_column_constraints_11 = {
+        "gpkg_data_column_constraints",
+        gpkg_data_column_constraints_columns_11,
+        NULL, 0
 };
 
 static column_info_t gpkg_metadata_columns[] = {
@@ -196,32 +213,136 @@ static table_info_t gpkg_metadata_reference = {
   NULL, 0
 };
 
-static const table_info_t *const gpkg_tables[] = {
-  &gpkg_contents,
-  &gpkg_extensions,
-  &gpkg_spatial_ref_sys,
-  &gpkg_data_columns,
-  &gpkg_data_column_constraints,
-  &gpkg_metadata,
-  &gpkg_metadata_reference,
-  &gpkg_geometry_columns,
-  &gpkg_tile_matrix_set,
-  &gpkg_tile_matrix,
+typedef struct {
+    const table_info_t *info;
+    const int check_flags;
+    const char *alt_check_flags_sql;
+    const int alt_check_flags;
+} gpkg_table_info_t;
+
+static gpkg_table_info_t gpkg_contents_info = {
+        &gpkg_contents,
+        SQL_MUST_EXIST,
+        NULL,
+        SQL_MUST_EXIST
+};
+static gpkg_table_info_t gpkg_extensions_info = {
+        &gpkg_extensions,
+        0,
+        NULL,
+        0
+};
+static gpkg_table_info_t gpkg_spatial_ref_sys_info = {
+        &gpkg_spatial_ref_sys,
+        SQL_MUST_EXIST,
+        NULL,
+        SQL_MUST_EXIST
+};
+static gpkg_table_info_t gpkg_data_columns_info = {
+        &gpkg_data_columns,
+        0,
+        NULL,
+        0
+};
+static gpkg_table_info_t gpkg_data_column_constraints_info_10 = {
+        &gpkg_data_column_constraints_10,
+        0,
+        NULL,
+        0
+};
+static gpkg_table_info_t gpkg_data_column_constraints_info_11 = {
+        &gpkg_data_column_constraints_11,
+        0,
+        NULL,
+        0
+};
+static gpkg_table_info_t gpkg_metadata_info = {
+        &gpkg_metadata,
+        0,
+        NULL,
+        0
+};
+static gpkg_table_info_t gpkg_metadata_reference_info = {
+        &gpkg_metadata_reference,
+        0,
+        NULL,
+        0
+};
+static gpkg_table_info_t gpkg_geometry_columns_info = {
+        &gpkg_geometry_columns,
+        0,
+        "SELECT count(*) FROM \"%w\".gpkg_contents WHERE data_type LIKE 'features'",
+        SQL_MUST_EXIST
+};
+static gpkg_table_info_t gpkg_tile_matrix_set_info = {
+        &gpkg_tile_matrix_set,
+        0,
+        "SELECT count(*) FROM \"%w\".gpkg_contents WHERE data_type LIKE 'tiles'",
+        SQL_MUST_EXIST
+};
+static gpkg_table_info_t gpkg_tile_matrix_info = {
+        &gpkg_tile_matrix,
+        0,
+        "SELECT count(*) FROM \"%w\".gpkg_contents WHERE data_type LIKE 'tiles'",
+        SQL_MUST_EXIST
+};
+
+static const int GPKG10_APPLICATION_ID = 0x47503130;
+
+static const gpkg_table_info_t * const gpkg10_tables[] = {
+  &gpkg_contents_info,
+  &gpkg_extensions_info,
+  &gpkg_spatial_ref_sys_info,
+  &gpkg_data_columns_info,
+  &gpkg_data_column_constraints_info_10,
+  &gpkg_metadata_info,
+  &gpkg_metadata_reference_info,
+  &gpkg_geometry_columns_info,
+  &gpkg_tile_matrix_set_info,
+  &gpkg_tile_matrix_info,
   NULL
 };
 
-static int init(sqlite3 *db, const char *db_name, errorstream_t *error) {
-  int result = SQLITE_OK;
-  const table_info_t *const *table = gpkg_tables;
+static const int GPKG11_APPLICATION_ID = 0x47503131;
 
-  result = sql_exec(db, "PRAGMA application_id = %d", 0x47503130);
-  if (result != SQLITE_OK) {
-    error_append(error, "Could not set application_id");
-  }
+static const gpkg_table_info_t * const gpkg11_tables[] = {
+  &gpkg_contents_info,
+  &gpkg_extensions_info,
+  &gpkg_spatial_ref_sys_info,
+  &gpkg_data_columns_info,
+  &gpkg_data_column_constraints_info_11,
+  &gpkg_metadata_info,
+  &gpkg_metadata_reference_info,
+  &gpkg_geometry_columns_info,
+  &gpkg_tile_matrix_set_info,
+  &gpkg_tile_matrix_info,
+  NULL
+};
+
+static const int GPKG12_APPLICATION_ID = 0x47504B47;
+static const int GPKG12_USER_VERSION = 0x000027D8;
+
+static const gpkg_table_info_t * const gpkg12_tables[] = {
+  &gpkg_contents_info,
+  &gpkg_extensions_info,
+  &gpkg_spatial_ref_sys_info,
+  &gpkg_data_columns_info,
+  &gpkg_data_column_constraints_info_11,
+  &gpkg_metadata_info,
+  &gpkg_metadata_reference_info,
+  &gpkg_geometry_columns_info,
+  &gpkg_tile_matrix_set_info,
+  &gpkg_tile_matrix_info,
+  NULL
+};
+
+static int create_tables(sqlite3 *db, const char *db_name, const gpkg_table_info_t *const *tables, errorstream_t *error) {
+  int result = SQLITE_OK;
+  const gpkg_table_info_t *const *table = tables;
 
   if (result == SQLITE_OK) {
     while (*table != NULL) {
-      result = sql_init_table(db, db_name, *table, error);
+      result = sql_init_table(db, db_name, (*table)->info, error);
       if (result != SQLITE_OK) {
         break;
       }
@@ -229,11 +350,58 @@ static int init(sqlite3 *db, const char *db_name, errorstream_t *error) {
     }
   }
 
-  if (result == SQLITE_OK && error_count(error) > 0) {
-    result = SQLITE_ERROR;
-  }
-
   return result;
+}
+
+static int init10(sqlite3 *db, const char *db_name, errorstream_t *error) {
+    int result = SQLITE_OK;
+
+    result = sql_set_application_id(db, db_name, GPKG10_APPLICATION_ID, error);
+
+    if (result == SQLITE_OK) {
+        result = create_tables(db, db_name, gpkg10_tables, error);
+    }
+
+    if (result == SQLITE_OK && error_count(error) > 0) {
+        result = SQLITE_ERROR;
+    }
+
+    return result;
+}
+
+static int init11(sqlite3 *db, const char *db_name, errorstream_t *error) {
+    int result = SQLITE_OK;
+
+    result = sql_set_application_id(db, db_name, GPKG11_APPLICATION_ID, error);
+
+    if (result == SQLITE_OK) {
+        result = create_tables(db, db_name, gpkg11_tables, error);
+    }
+
+    if (result == SQLITE_OK && error_count(error) > 0) {
+        result = SQLITE_ERROR;
+    }
+
+    return result;
+}
+
+static int init12(sqlite3 *db, const char *db_name, errorstream_t *error) {
+    int result = SQLITE_OK;
+
+    result = sql_set_application_id(db, db_name, GPKG12_APPLICATION_ID, error);
+    if (result == SQLITE_OK) {
+        result = sql_set_user_version(db, db_name, GPKG12_USER_VERSION, error);
+    }
+
+    if (result == SQLITE_OK) {
+        result = create_tables(db, db_name, gpkg12_tables, error);
+    }
+
+    if (result == SQLITE_OK && error_count(error) > 0) {
+        result = SQLITE_ERROR;
+    }
+
+    return result;
 }
 
 /*
@@ -398,44 +566,27 @@ static check_func checks[] = {
   NULL
 };
 
-static int check(sqlite3 *db, const char *db_name, int flags, errorstream_t *error) {
+static int check(sqlite3 *db, const char *db_name, int flags, const gpkg_table_info_t *const *tables, check_func *checks, errorstream_t *error) {
   int result = SQLITE_OK;
 
-  if (result == SQLITE_OK) {
-    result = sql_check_table(db, db_name, &gpkg_contents, SQL_MUST_EXIST | flags, error);
-  }
-  if (result == SQLITE_OK) {
-    result = sql_check_table(db, db_name, &gpkg_spatial_ref_sys, SQL_MUST_EXIST | flags, error);
-  }
-  if (result == SQLITE_OK) {
-    result = sql_check_table(db, db_name, &gpkg_extensions, flags, error);
-  }
-  if (result == SQLITE_OK) {
-    result = sql_check_table(db, db_name, &gpkg_data_columns, flags, error);
-  }
-  if (result == SQLITE_OK) {
-    result = sql_check_table(db, db_name, &gpkg_data_column_constraints, flags, error);
-  }
-  if (result == SQLITE_OK) {
-    result = sql_check_table(db, db_name, &gpkg_metadata, flags, error);
-  }
-  if (result == SQLITE_OK) {
-    result = sql_check_table(db, db_name, &gpkg_metadata_reference, flags, error);
-  }
-  if (result == SQLITE_OK) {
-    int features = 0;
-    result = sql_exec_for_int(db, &features, "SELECT count(*) FROM \"%w\".gpkg_contents WHERE data_type LIKE 'features'", db_name);
-    if (result == SQLITE_OK) {
-      result = sql_check_table(db, db_name, &gpkg_geometry_columns, flags | (features > 0 ? SQL_MUST_EXIST : 0), error);
+  const gpkg_table_info_t *const *table = tables;
+
+  while (*table != NULL) {
+    const gpkg_table_info_t *table_info = *table;
+    int check_flags = table_info->check_flags;
+    if (table_info->alt_check_flags_sql != NULL) {
+        int sql_result = 0;
+        result = sql_exec_for_int(db, &sql_result, (char *) table_info->alt_check_flags_sql, db_name);
+        if (result == SQLITE_OK && sql_result > 0) {
+            check_flags = table_info->alt_check_flags;
+        }
     }
-  }
-  if (result == SQLITE_OK) {
-    int tiles = 0;
-    result = sql_exec_for_int(db, &tiles, "SELECT count(*) FROM \"%w\".gpkg_contents WHERE data_type LIKE 'tiles'", db_name);
-    if (result == SQLITE_OK) {
-      result = sql_check_table(db, db_name, &gpkg_tile_matrix_set, flags | (tiles > 0 ? SQL_MUST_EXIST : 0), error);
-      result = sql_check_table(db, db_name, &gpkg_tile_matrix, flags | (tiles > 0 ? SQL_MUST_EXIST : 0), error);
+
+    result = sql_check_table(db, db_name, table_info->info, check_flags | flags, error);
+    if (result != SQLITE_OK) {
+      break;
     }
+    table++; 
   }
 
   if ((flags & SQL_CHECK_ALL_DATA) != 0) {
@@ -455,6 +606,75 @@ static int check(sqlite3 *db, const char *db_name, int flags, errorstream_t *err
   }
 
   return result;
+}
+
+static int check_application_id(sqlite3 *db, const char *db_name, int expected, errorstream_t *error) {
+    int application_id = 0;
+    int result = sql_get_application_id(db, db_name, &application_id, error);
+    if (result == SQLITE_OK && application_id != expected) {
+        error_append(error, "Incorrect application_id: expected 0x%x, actual 0x%x", expected, application_id);
+    }
+    return result;
+}
+
+static int check_user_version(sqlite3 *db, const char *db_name, int expected, errorstream_t *error) {
+    int application_id = 0;
+    int result = sql_get_user_version(db, db_name, &application_id, error);
+    if (result == SQLITE_OK && application_id != expected) {
+        error_append(error, "Incorrect user_version: expected 0x%x, actual 0x%x", expected, application_id);
+    }
+    return result;
+}
+
+static int check10(sqlite3 *db, const char *db_name, int flags, errorstream_t *error) {
+    int result = SQLITE_OK;
+
+    result = check_application_id(db, db_name, GPKG10_APPLICATION_ID, error);
+
+    if (result == SQLITE_OK) {
+        result = check(db, db_name, flags, gpkg10_tables, checks, error);
+    }
+
+    if (result == SQLITE_OK && error_count(error) > 0) {
+        result = SQLITE_ERROR;
+    }
+
+    return result;
+}
+
+static int check11(sqlite3 *db, const char *db_name, int flags, errorstream_t *error) {
+    int result = SQLITE_OK;
+
+    result = check_application_id(db, db_name, GPKG11_APPLICATION_ID, error);
+
+    if (result == SQLITE_OK) {
+        result = check(db, db_name, flags, gpkg11_tables, checks, error);
+    }
+
+    if (result == SQLITE_OK && error_count(error) > 0) {
+        result = SQLITE_ERROR;
+    }
+
+    return result;
+}
+
+static int check12(sqlite3 *db, const char *db_name, int flags, errorstream_t *error) {
+    int result = SQLITE_OK;
+
+    result = check_application_id(db, db_name, GPKG12_APPLICATION_ID, error);
+    if (result == SQLITE_OK) {
+        result = check_user_version(db, db_name, GPKG12_USER_VERSION, error);
+    }
+
+    if (result == SQLITE_OK) {
+        result = check(db, db_name, flags, gpkg12_tables, checks, error);
+    }
+
+    if (result == SQLITE_OK && error_count(error) > 0) {
+        result = SQLITE_ERROR;
+    }
+
+    return result;
 }
 
 static int write_blob_header(binstream_t *stream, geom_blob_header_t *header, errorstream_t *error) {
@@ -787,11 +1007,11 @@ static int read_geometry(binstream_t *stream, geom_consumer_t const *consumer, e
   return wkb_read_geometry(stream, WKB_ISO, consumer, error);
 }
 
-static const spatialdb_t GEOPACKAGE = {
-  "GeoPackage",
+static const spatialdb_t GEOPACKAGE_10 = {
+  "GeoPackage 1.0",
   NULL,
-  init,
-  check,
+  init10,
+  check10,
   write_blob_header,
   read_blob_header,
   gpkg_writer_init,
@@ -805,6 +1025,50 @@ static const spatialdb_t GEOPACKAGE = {
   read_geometry
 };
 
-const spatialdb_t *spatialdb_geopackage_schema() {
-  return &GEOPACKAGE;
+const spatialdb_t *spatialdb_geopackage10_schema() {
+  return &GEOPACKAGE_10;
+}
+
+static const spatialdb_t GEOPACKAGE_11 = {
+        "GeoPackage 1.1",
+        NULL,
+        init11,
+        check11,
+        write_blob_header,
+        read_blob_header,
+        gpkg_writer_init,
+        gpb_writer_init,
+        gpb_writer_destroy,
+        add_geometry_column,
+        create_tiles_table,
+        create_spatial_index,
+        fill_envelope,
+        read_geometry_header,
+        read_geometry
+};
+
+const spatialdb_t *spatialdb_geopackage11_schema() {
+    return &GEOPACKAGE_11;
+}
+
+static const spatialdb_t GEOPACKAGE_12 = {
+        "GeoPackage 1.2",
+        NULL,
+        init12,
+        check12,
+        write_blob_header,
+        read_blob_header,
+        gpkg_writer_init,
+        gpb_writer_init,
+        gpb_writer_destroy,
+        add_geometry_column,
+        create_tiles_table,
+        create_spatial_index,
+        fill_envelope,
+        read_geometry_header,
+        read_geometry
+};
+
+const spatialdb_t *spatialdb_geopackage12_schema() {
+    return &GEOPACKAGE_12;
 }

--- a/gpkg/spatialdb.c
+++ b/gpkg/spatialdb.c
@@ -706,7 +706,9 @@ const spatialdb_t *spatialdb_detect_schema(sqlite3 *db) {
   error_init_fixed(&error, message_buffer, 256);
 
   const spatialdb_t *schemas[] = {
-    spatialdb_geopackage_schema(),
+    spatialdb_geopackage12_schema(),
+    spatialdb_geopackage11_schema(),
+    spatialdb_geopackage10_schema(),
     spatialdb_spatialite4_schema(),
     spatialdb_spatialite3_schema(),
     spatialdb_spatialite2_schema(),

--- a/gpkg/spatialdb.h
+++ b/gpkg/spatialdb.h
@@ -100,7 +100,17 @@ typedef struct spatialdb {
 /**
  * Returns the GeoPackage spatial database schema.
  */
-const spatialdb_t *spatialdb_geopackage_schema();
+const spatialdb_t *spatialdb_geopackage10_schema();
+
+/**
+ * Returns the GeoPackage spatial database schema.
+ */
+const spatialdb_t *spatialdb_geopackage11_schema();
+
+/**
+ * Returns the GeoPackage spatial database schema.
+ */
+const spatialdb_t *spatialdb_geopackage12_schema();
 
 /**
  * Returns the Spatialite 2.x spatial database schema.

--- a/gpkg/sql.c
+++ b/gpkg/sql.c
@@ -987,3 +987,35 @@ int sql_create_function(sqlite3 *db, const char *name, void (*function)(sqlite3_
 
   return result;
 }
+
+int sql_get_application_id(sqlite3 *db, const char *db_name, int *out, errorstream_t *error) {
+  int result = sql_exec_for_int(db, out, "PRAGMA %w.application_id", db_name);
+  if (result != SQLITE_OK) {
+    error_append(error, "Could not get application_id: %s", sqlite3_errmsg(db));
+  }
+  return result;
+}
+
+int sql_set_application_id(sqlite3 *db, const char *db_name, int application_id, errorstream_t *error) {
+  int result = sql_exec(db, "PRAGMA %w.application_id = %d", db_name, application_id);
+  if (result != SQLITE_OK) {
+    error_append(error, "Could not set application_id: %s", sqlite3_errmsg(db));
+  }
+  return result;
+}
+
+int sql_get_user_version(sqlite3 *db, const char *db_name, int *out, errorstream_t *error) {
+  int result = sql_exec_for_int(db, out, "PRAGMA %w.user_version", db_name);
+  if (result != SQLITE_OK) {
+    error_append(error, "Could not get user_version: %s", sqlite3_errmsg(db));
+  }
+  return result;
+}
+
+int sql_set_user_version(sqlite3 *db, const char *db_name, int user_version, errorstream_t *error) {
+  int result = sql_exec(db, "PRAGMA %w.user_version = %d", db_name, user_version);
+  if (result != SQLITE_OK) {
+    error_append(error, "Could not set user_version: %s", sqlite3_errmsg(db));
+  }
+  return result;
+}

--- a/gpkg/sql.h
+++ b/gpkg/sql.h
@@ -367,6 +367,14 @@ typedef void(sql_function)(sqlite3_context *, int, sqlite3_value **);
 
 int sql_create_function(sqlite3 *db, const char *name, sql_function *function, int args, int flags, void *user_data, void (*destroy)(void *), errorstream_t *error);
 
+int sql_set_application_id(sqlite3 *db, const char *db_name, int application_id, errorstream_t *error);
+
+int sql_get_application_id(sqlite3 *db, const char *db_name, int *application_id, errorstream_t *error);
+
+int sql_set_user_version(sqlite3 *db, const char *db_name, int user_version, errorstream_t *error);
+
+int sql_get_user_version(sqlite3 *db, const char *db_name, int *user_version, errorstream_t *error);
+
 /** @} */
 
 #endif

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -4350,11 +4350,11 @@ int main(int argc, char **argv){
     }else if( strcmp(z,"-gpkg")==0 ){
       data.gpkgEntryPoint = sqlite3_gpkg_init;
     }else if( strcmp(z,"-gpkg10")==0 ){
-      data.gpkgEntryPoint = sqlite3_gpkg1_0_init;
+      data.gpkgEntryPoint = sqlite3_gpkg_1_0_init;
     }else if( strcmp(z,"-gpkg11")==0 ){
-      data.gpkgEntryPoint = sqlite3_gpkg1_1_init;
+      data.gpkgEntryPoint = sqlite3_gpkg_1_1_init;
     }else if( strcmp(z,"-gpkg12")==0 ){
-      data.gpkgEntryPoint = sqlite3_gpkg1_2_init;
+      data.gpkgEntryPoint = sqlite3_gpkg_1_2_init;
     }else if( strcmp(z,"-spl3")==0 ){
       data.gpkgEntryPoint = sqlite3_gpkg_spl3_init;
     }else if( strcmp(z,"-spl4")==0 ){

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -4107,7 +4107,10 @@ static const char zOptions[] =
   "   -csv                 set output mode to 'csv'\n"
   "   -echo                print commands before execution\n"
   "   -init FILENAME       read/process named file\n"
-  "   -gpkg                use the GeoPackage database schema\n"
+  "   -gpkg                use the latest GeoPackage database schema\n"
+  "   -gpkg10              use the GeoPackage 1.0 database schema\n"
+  "   -gpkg11              use the GeoPackage 1.1 database schema\n"
+  "   -gpkg12              use the GeoPackage 1.2 database schema\n"
   "   -[no]header          turn headers on or off\n"
 #if defined(SQLITE_ENABLE_MEMSYS3) || defined(SQLITE_ENABLE_MEMSYS5)
   "   -heap SIZE           Size of heap for memsys3 or memsys5\n"
@@ -4346,6 +4349,12 @@ int main(int argc, char **argv){
       }
     }else if( strcmp(z,"-gpkg")==0 ){
       data.gpkgEntryPoint = sqlite3_gpkg_init;
+    }else if( strcmp(z,"-gpkg10")==0 ){
+      data.gpkgEntryPoint = sqlite3_gpkg1_0_init;
+    }else if( strcmp(z,"-gpkg11")==0 ){
+      data.gpkgEntryPoint = sqlite3_gpkg1_1_init;
+    }else if( strcmp(z,"-gpkg12")==0 ){
+      data.gpkgEntryPoint = sqlite3_gpkg1_2_init;
     }else if( strcmp(z,"-spl3")==0 ){
       data.gpkgEntryPoint = sqlite3_gpkg_spl3_init;
     }else if( strcmp(z,"-spl4")==0 ){

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ execute_process(
 #
 # Generate a cmake test for each (libgpkg entry point, spec file) combination.
 #
-set(entry_points gpkg1_0 gpkg1_1 gpkg1_2 gpkg_spl3 gpkg_spl4)
+set(entry_points gpkg_1_0 gpkg_1_1 gpkg_1_2 gpkg_spl3 gpkg_spl4)
 
 file(GLOB test_scripts RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *_spec.rb)
 foreach(entry_point IN LISTS entry_points)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ execute_process(
 #
 # Generate a cmake test for each (libgpkg entry point, spec file) combination.
 #
-set(entry_points gpkg gpkg_spl3 gpkg_spl4)
+set(entry_points gpkg1_0 gpkg1_1 gpkg1_2 gpkg_spl3 gpkg_spl4)
 
 file(GLOB test_scripts RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *_spec.rb)
 foreach(entry_point IN LISTS entry_points)

--- a/test/gpkg.rb
+++ b/test/gpkg.rb
@@ -66,7 +66,15 @@ module GeoPackage
 
   module Helpers
     def self.mode
-      ENV['GPKG_ENTRY_POINT'].match(/^(?:gpkg_)?(.*)/)[1].to_sym
+      entry_point = ENV['GPKG_ENTRY_POINT']
+      case ENV['GPKG_ENTRY_POINT']
+        when /^gpkg_(spl\d+)/
+          $1.to_sym
+        when /^gpkg\d+_\d+/
+          :gpkg
+        else
+          fail("Could not determine test mode for #{entry_point}")
+      end
     end
 
     def self.geos_version

--- a/test/gpkg.rb
+++ b/test/gpkg.rb
@@ -70,7 +70,7 @@ module GeoPackage
       case ENV['GPKG_ENTRY_POINT']
         when /^gpkg_(spl\d+)/
           $1.to_sym
-        when /^gpkg\d+_\d+/
+        when /^gpkg_\d+_\d+/
           :gpkg
         else
           fail("Could not determine test mode for #{entry_point}")


### PR DESCRIPTION
This PR adds initial infrastructure to allow libgpkg to support multiple versions of the GeoPackage specification.
As an initial test I've added application_id/user_version checking and added the change to the schema of `gpkg_data_column_constraints` requested in PR #1.